### PR TITLE
Puppets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-master
+of

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-of
+puppets


### PR DESCRIPTION
The 's' at the end of README.md is too correct and can be used as a example of good grammar. This is not useless enough, please let me remove the 's'.